### PR TITLE
Fix dotenv import typo

### DIFF
--- a/ai-service/app.py
+++ b/ai-service/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
-from dotenv import load_load_dotenv
+from dotenv import load_dotenv
 import os
 import logging
 from logging.handlers import RotatingFileHandler


### PR DESCRIPTION
## Summary
- fix typo when importing `load_dotenv`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879f9a1cd988330a249d8454671c656